### PR TITLE
More updates to "A tour of Unison" to reflect latest UCM output

### DIFF
--- a/src/data/docs/tour/README.md
+++ b/src/data/docs/tour/README.md
@@ -491,17 +491,15 @@ show-carets: true
 
   I added these definitions to the top of ~/unisoncode/scratch.u
 
-    square : .base.Nat -> .base.Nat
+    square : Nat -> Nat
     square x =
-      use .base.Nat *
+      use Nat *
       x * x
 
   You can edit them there, then do `update` to replace the definitions currently in this branch.
 ```
 
 This copies the pretty-printed definition of `square` into you scratch file "above the fold". That is, it adds a line starting with `---` and puts whatever was already in the file below this line. Unison ignores any file contents below the fold.
-
-> Notice that Unison has put the correct type signature on `square`. The absolute names `.base.Nat` look a bit funny. We will often do `use .base` at the top of our file to refer to all the basic functions and types in `.base` without a fully qualified name.
 
 Let's edit `square` and instead define `square x` (just for fun) as the sum of the first `x` odd numbers (here's a [nice geometric illustration of why this gives the same results](https://math.stackexchange.com/a/639079)):
 
@@ -513,7 +511,7 @@ square x =
   sum (map (x -> x * 2 + 1) (range 0 x))
 
 sum : [Nat] -> Nat
-sum = foldl (+) 0
+sum = foldLeft (+) 0
 ```
 
 ```
@@ -526,11 +524,13 @@ show-carets: true
 I found and typechecked these definitions in ~/unisoncode/scratch.u. If you do an
 `add` or `update` , here's how your codebase would change:
 
-  ⍟ These new definitions will replace existing ones of the same name and are ok to `update`:
+    ⍟ These new definitions are ok to `add`:
 
-    square : .base.Nat -> .base.Nat
+      sum : [Nat] -> Nat
 
-Now evaluating any watch expressions (lines starting with `>`)... Ctrl+C cancels.
+    ⍟ These names already exist. You can `update` them to your new definition:
+
+      square : Nat -> Nat
 ```
 
 ### Adding an updated definition to the codebase
@@ -546,11 +546,11 @@ show-carets: true
 
   ⍟ I've added these definitions:
 
-    sum : [.base.Nat] -> .base.Nat
+    sum : [Nat] -> Nat
 
-  ⍟ I've updated to these definitions:
+  ⍟ I've updated these names to your new definition:
 
-    square             : .base.Nat -> .base.Nat
+    square : Nat -> Nat
 ```
 
 ### Only affected tests are rerun on `update`
@@ -564,14 +564,16 @@ show-carets: true
 ---
 .mylibrary> test
 
-  New test results:
+  ✅
+  
+    New test results:
 
+  ◉ square.tests.ex1      : Proved.
   ◉ square.tests.prop1    : Passed 100 tests.
-  ◉ square.tests.ex1      : Passed 1 tests.
 
   ✅ 2 test(s) passing
 
-  Tip: Use view square.tests.prop1 to view the source of a test.
+  Tip: Use view square.tests.ex1 to view the source of a test.
 ```
 
 Notice the message indicates that the tests weren't cached. If we do `test` again, we'll get the newly cached results.
@@ -580,7 +582,7 @@ The dependency tracking for determining whether a test needs rerunning is 100% a
 
 ## Publishing code and installing Unison libraries
 
-Code is published using the `push` command and libraries are installed just via the `pull` command (recall how in the [quickstart guide](/docs/quickstart), we installed the base libraries with a `pull`). There's no separate tooling needed for managing dependencies or publishing code and you'll never encounter dependency conflicts in Unison. 
+Code is published using the `push` command and libraries are installed via the `pull` command (recall how in the [quickstart guide](/docs/quickstart), we installed the base libraries with a `pull`). There's no separate tooling needed for managing dependencies or publishing code and you'll never encounter dependency conflicts in Unison. 
 
 [This document](/docs/codebase-organization) covers the details of how to organize your codebase, issue and review pull requests, install libraries, and make releases.
 


### PR DESCRIPTION
Most of these are more changes to reflect the current UCM output. Mostly around `Proved.` vs. `Passed 1 tests.`, and around UCM making less use of absolute namespaces.

The `update` of `square` no longer adds in full namespaces, so I removed that comment explaining why UCM does that.

Lastly, `foldl` is actually named `foldLeft`, but the code explaining `update` at the end of the tour used `foldl`, causing a missing definition for anyone following along in the tour (earlier the tour does have the user rename `foldLeft` to `foldl` to explain term renaming, but the tour then has them undo this change).